### PR TITLE
Trying to fix relative paths in srcset attribute

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,12 @@ function relativeLinks({ config }: { config?: AstroConfig }): AstroIntegration {
               path.relative(path.dirname(filePath), dir.pathname) || '.';
 
             const result = html.replace(pattern, `$1="${relativePath}/`);
+            
+            const pattern2 = new RegExp(`(,\\s)${base}`, 'g');
+            
+            const result2 = result.replace(pattern2, `$1${relativePath}/`);
 
-            writeFileSync(filePath, result, 'utf8');
+            writeFileSync(filePath, result2, 'utf8');
           });
         } catch (error) {
           console.log(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ function relativeLinks({ config }: { config?: AstroConfig }): AstroIntegration {
 
             const result = html.replace(pattern, `$1="${relativePath}/`);
             
-            const pattern2 = new RegExp(`(,\\s)${base}`, 'g');
+            const pattern2 = new RegExp(`(,\\s)${base}/`, 'g');
             
             const result2 = result.replace(pattern2, `$1${relativePath}/`);
 


### PR DESCRIPTION
Hey there, thank you for great plugin, it is very useful and needed.

It perfectly works with `href` and `src` attributes, but I often use `srcset` attribute for retina images:
```html
<img src="pic.png" srcset="pic@2x.png 2x, pic@3x.png 3x">
```
I've tried to change code to solve this problem by myself, but I think my solution terrifying.
In my opinion, my regular expression is not safe enough for production, because it's too open. It will replace all `, /`, but maybe there is the way to exec it only in `srcset` attribute?