### PR TITLE
Fix bug when pathname includes spaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ function relativeLinks({ config }: { config?: AstroConfig }): AstroIntegration {
 
         try {
           // HTML
-          globSync(`${dir.pathname}**/*.html`).forEach((filePath) => {
+          globSync(`${outDirPath}**/*.html`).forEach((filePath) => {
             writeFileSync(
               filePath,
               replaceHTML({
@@ -107,7 +107,7 @@ function relativeLinks({ config }: { config?: AstroConfig }): AstroIntegration {
           });
 
           // CSS
-          globSync(`${dir.pathname}**/*.css`).forEach((filePath) => {
+          globSync(`${outDirPath}**/*.css`).forEach((filePath) => {
             writeFileSync(
               filePath,
               replaceCSS({


### PR DESCRIPTION
When calling `globSync`, this previously used `dir.pathname`, which returns an invalid value (contains URL encoding) for pathnames with spaces. I switched it for `outDirPath`, which represents the same value but doesn't have that issue.